### PR TITLE
Fixed the index.js issue.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,0 @@
-node_modules

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-i18n-localize",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "",
   "license": "MIT",
   "repository": "filaraujo/gulp-i18n-localize",
@@ -16,10 +16,6 @@
     "test": "mocha"
   },
   "main": "./index.js",
-  "files": [
-    "index.js",
-    "test"
-  ],
   "keywords": [
     "gulpplugin, i18n, internationalization, translation, translate"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-i18n-localize",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "",
   "license": "MIT",
   "repository": "filaraujo/gulp-i18n-localize",
@@ -16,6 +16,13 @@
     "test": "mocha"
   },
   "main": "./index.js",
+  "files": [
+    "index.js",
+    "license",
+    "readme.md",
+    "package.json",
+    "test"
+  ],
   "keywords": [
     "gulpplugin, i18n, internationalization, translation, translate"
   ],

--- a/package.json
+++ b/package.json
@@ -15,6 +15,11 @@
   "scripts": {
     "test": "mocha"
   },
+  "main": "./index.js",
+  "files": [
+    "index.js",
+    "test"
+  ],
   "keywords": [
     "gulpplugin, i18n, internationalization, translation, translate"
   ],


### PR DESCRIPTION
This issue seems to be a direct result of switching from Node 5.XX to 6.  In order to resolve it, you must perform the following two steps:
- Remove `.npmignore` in favor of using the **"files"** attribute of `package.json` (fixed with 0cb5f90).
- Remove the `./node_modules` directory from the package root before packing/publishing the module.
