### PR TITLE
Enabling no cache

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,7 +99,7 @@ module.exports = function(options) {
 
   try {
     fs.accessSync(localeDir);
-    options.dictionary = requireDir(localeDir, {recurse: true});
+    options.dictionary = requireDir(localeDir, {recurse: true, noCache: true});
   } catch (e) {
     gutil.log('gulp-i18n-localize: locale directory not found');
     options.dictionary = false;

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "gulp-util": "^3.0.1",
     "istextorbinary": "^2.1.0",
-    "require-dir": "^0.3.0",
+    "require-dir": "git@github.com:VincentRoth/requireDir.git#d43a5e2",
     "through2": "^0.6.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "gulp-util": "^3.0.1",
     "istextorbinary": "^2.1.0",
-    "require-dir": "git@github.com:VincentRoth/requireDir.git#d43a5e2",
+    "require-dir": "^1.1.0",
     "through2": "^0.6.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Hi,

I got trouble with some gulp.watch to refresh my whole build, as the directory content watcedh by gulp-i18n-localize is cached by require-dir.
Now, require-dir has an option to remove file caching, so new file content is used to localize.

Is it OK for you to merge this PR ?

Regards